### PR TITLE
Fix cpanm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ INSTALLATION
 In addition to perl, RCFV Reader uses the cpan module FAST::Bio::SeqIO
 You can install this module using:
 
-cpanm FAST::Bio
+```bash
+cpanm FAST
+```
 
 If you don't have cpan, you can get it here:
 https://www.cpan.org/


### PR DESCRIPTION
When I tried installing `FAST::Bio` using the command in the README:

```bash
cpanm FAST::Bio
```

I got the following error message:

```
! Finding FAST::Bio on cpanmetadb failed.
! Finding FAST::Bio () on mirror http://www.cpan.org failed.
! Couldn't find module or a distribution FAST::Bio
```

When I tried the following instead:

```bash
cpanm FAST
```

It installed just fine:

```
--> Working on FAST
Fetching http://www.cpan.org/authors/id/D/DH/DHARD/FAST-1.06.tar.gz ... OK
Configuring FAST-1.06 ... OK
==> Found dependencies: Sort::MergeSort, Sort::Key, Bit::Vector
--> Working on Sort::MergeSort
Fetching http://www.cpan.org/authors/id/M/MU/MUIR/modules/Sort-MergeSort-0.31.tar.gz ... OK
Configuring Sort-MergeSort-0.31 ... OK
==> Found dependencies: Test::NoWarnings
--> Working on Test::NoWarnings
Fetching http://www.cpan.org/authors/id/H/HA/HAARG/Test-NoWarnings-1.06.tar.gz ... OK
Configuring Test-NoWarnings-1.06 ... OK
Building and testing Test-NoWarnings-1.06 ... OK
Successfully installed Test-NoWarnings-1.06
Building and testing Sort-MergeSort-0.31 ... OK
Successfully installed Sort-MergeSort-0.31
--> Working on Sort::Key
Fetching http://www.cpan.org/authors/id/S/SA/SALVA/Sort-Key-1.33.tar.gz ... OK
Configuring Sort-Key-1.33 ... OK
Building and testing Sort-Key-1.33 ... OK
Successfully installed Sort-Key-1.33
--> Working on Bit::Vector
Fetching http://www.cpan.org/authors/id/S/ST/STBEY/Bit-Vector-7.4.tar.gz ... OK
Configuring Bit-Vector-7.4 ... OK
==> Found dependencies: Carp::Clan
--> Working on Carp::Clan
Fetching http://www.cpan.org/authors/id/E/ET/ETHER/Carp-Clan-6.08.tar.gz ... OK
Configuring Carp-Clan-6.08 ... OK
Building and testing Carp-Clan-6.08 ... OK
Successfully installed Carp-Clan-6.08
Building and testing Bit-Vector-7.4 ... OK
Successfully installed Bit-Vector-7.4
Building and testing FAST-1.06 ... OK
Successfully installed FAST-1.06
6 distributions installed
```